### PR TITLE
Update isaaclab and rsl_rl dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -87,8 +87,8 @@
     // Python extra paths
     // Note: this is filled up when "./isaaclab.sh -i" is run
     "python.analysis.extraPaths": [
-        "~/workspace/dev/IsaacLab/source/extensions/omni.isaac.lab_assets",
-        "~/workspace/dev/IsaacLab/source/extensions/omni.isaac.lab_tasks",
-        "~/workspace/dev/IsaacLab/source/extensions/omni.isaac.lab"
+        "~/workspace/dev/IsaacLab/source/extensions/isaaclab_assets",
+        "~/workspace/dev/IsaacLab/source/extensions/isaaclab_tasks",
+        "~/workspace/dev/IsaacLab/source/extensions/isaaclab"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ python3 scripts/tools/convert_urdf.py urdf/your_urdf.urdf usd/your_usd.usd
 ### About isaac nucleus
 If you dont want to use the assets in isaac nucleus, please comment the following code and replace it with your own assets path.
 ```bash
-from omni.isaac.lab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 # from isaacLab.manipulation.assets.config import your_robot
 ```
 ### RL Algorithm

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ mkdir isaacLab.manipulation/isaacLab/manipulation/algorithms
 cd isaacLab.manipulation/isaacLab/manipulation/algorithms
 git clone https://github.com/leggedrobotics/rsl_rl.git
 cd rsl_rl
+# IMPORTANT: Use a specific version of rsl_rl that is compatible with this project
+git checkout 73fd7c6  # v2.0.1 release
 python -m pip install -e .
 
 ## refresh index

--- a/config/extension.toml
+++ b/config/extension.toml
@@ -19,9 +19,9 @@ keywords = ["extension", "template", "isaacLab"]
 # -----------------------------------------------------------------
 
 [dependencies]
-"omni.isaac.lab" = {}
-"omni.isaac.lab_assets" = {}
-"omni.isaac.lab_tasks" = {}
+"isaaclab" = {}
+"isaaclab_assets" = {}
+"isaaclab_tasks" = {}
 # NOTE: Add additional dependencies here
 
 [[python.module]]

--- a/isaacLab/manipulation/assets/config/kinova_gripper.py
+++ b/isaacLab/manipulation/assets/config/kinova_gripper.py
@@ -14,9 +14,9 @@ The following configuration parameters are available:
 Reference: https://github.com/Kinovarobotics/kinova-ros
 """
 
-import omni.isaac.lab.sim as sim_utils
-from omni.isaac.lab.actuators import ImplicitActuatorCfg
-from omni.isaac.lab.assets.articulation import ArticulationCfg
+import isaaclab.sim as sim_utils
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.assets.articulation import ArticulationCfg
 import os
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/config/allegro_hand/__init__.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/config/allegro_hand/__init__.py
@@ -17,7 +17,7 @@ from . import agents, allegro_env_cfg
 
 gym.register(
     id="Template-Isaac-Repose-Cube-Allegro-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": allegro_env_cfg.AllegroCubeEnvCfg,
@@ -29,7 +29,7 @@ gym.register(
 
 gym.register(
     id="Template-Isaac-Repose-Cube-Allegro-Play-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": allegro_env_cfg.AllegroCubeEnvCfg_PLAY,
@@ -45,7 +45,7 @@ gym.register(
 
 gym.register(
     id="Template-Isaac-Repose-Cube-Allegro-NoVelObs-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": allegro_env_cfg.AllegroCubeNoVelObsEnvCfg,
@@ -57,7 +57,7 @@ gym.register(
 
 gym.register(
     id="Template-Isaac-Repose-Cube-Allegro-NoVelObs-Play-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": allegro_env_cfg.AllegroCubeNoVelObsEnvCfg_PLAY,

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/config/allegro_hand/agents/rsl_rl_cfg.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/config/allegro_hand/agents/rsl_rl_cfg.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from omni.isaac.lab.utils import configclass
+from isaaclab.utils import configclass
 
-from omni.isaac.lab_tasks.utils.wrappers.rsl_rl import (
+from isaaclab_rl.rsl_rl import (
     RslRlOnPolicyRunnerCfg,
     RslRlPpoActorCriticCfg,
     RslRlPpoAlgorithmCfg,

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/config/allegro_hand/allegro_env_cfg.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/config/allegro_hand/allegro_env_cfg.py
@@ -3,17 +3,17 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from omni.isaac.lab.utils import configclass
+from isaaclab.utils import configclass
 
 #import isaacLab.manipulation.tasks.Robot_arm.reach.mdp as mdp
 import isaacLab.manipulation.tasks.Dextrous_hand.inhand.mdp as mdp
 import isaacLab.manipulation.tasks.Dextrous_hand.inhand.inhand_env_cfg as inhand_env_cfg
-#import omni.isaac.lab_tasks.manager_based.manipulation.inhand.inhand_env_cfg as inhand_env_cfg
+#import isaaclab_tasks.manager_based.manipulation.inhand.inhand_env_cfg as inhand_env_cfg
 
 ##
 # Pre-defined configs
 ##
-from omni.isaac.lab_assets import ALLEGRO_HAND_CFG  # isort: skip
+from isaaclab_assets import ALLEGRO_HAND_CFG  # isort: skip
 
 
 @configclass

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/inhand_env_cfg.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/inhand_env_cfg.py
@@ -7,21 +7,21 @@ from __future__ import annotations
 
 from dataclasses import MISSING
 
-import omni.isaac.lab.sim as sim_utils
-from omni.isaac.lab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
-from omni.isaac.lab.envs import ManagerBasedRLEnvCfg
-from omni.isaac.lab.managers import EventTermCfg as EventTerm
-from omni.isaac.lab.managers import ObservationGroupCfg as ObsGroup
-from omni.isaac.lab.managers import ObservationTermCfg as ObsTerm
-from omni.isaac.lab.managers import RewardTermCfg as RewTerm
-from omni.isaac.lab.managers import SceneEntityCfg
-from omni.isaac.lab.managers import TerminationTermCfg as DoneTerm
-from omni.isaac.lab.scene import InteractiveSceneCfg
-from omni.isaac.lab.sim.simulation_cfg import PhysxCfg, SimulationCfg
-from omni.isaac.lab.sim.spawners.materials.physics_materials_cfg import RigidBodyMaterialCfg
-from omni.isaac.lab.utils import configclass
-from omni.isaac.lab.utils.assets import ISAAC_NUCLEUS_DIR
-from omni.isaac.lab.utils.noise import AdditiveGaussianNoiseCfg as Gnoise
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
+from isaaclab.envs import ManagerBasedRLEnvCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sim.simulation_cfg import PhysxCfg, SimulationCfg
+from isaaclab.sim.spawners.materials.physics_materials_cfg import RigidBodyMaterialCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils.noise import AdditiveGaussianNoiseCfg as Gnoise
 
 import isaacLab.manipulation.tasks.Dextrous_hand.inhand.mdp as mdp
 

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/__init__.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/__init__.py
@@ -5,7 +5,7 @@
 
 """This sub-module contains the functions that are specific to the in-hand manipulation environments."""
 
-from omni.isaac.lab.envs.mdp import *  # noqa: F401, F403
+from isaaclab.envs.mdp import *  # noqa: F401, F403
 
 from .commands import *  # noqa: F401, F403
 from .events import *  # noqa: F401, F403

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/commands/commands_cfg.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/commands/commands_cfg.py
@@ -5,11 +5,11 @@
 
 from dataclasses import MISSING
 
-import omni.isaac.lab.sim as sim_utils
-from omni.isaac.lab.managers import CommandTermCfg
-from omni.isaac.lab.markers import VisualizationMarkersCfg
-from omni.isaac.lab.utils import configclass
-from omni.isaac.lab.utils.assets import ISAAC_NUCLEUS_DIR
+import isaaclab.sim as sim_utils
+from isaaclab.managers import CommandTermCfg
+from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
 from .orientation_command import InHandReOrientationCommand
 

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/commands/orientation_command.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/commands/orientation_command.py
@@ -11,13 +11,13 @@ import torch
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-import omni.isaac.lab.utils.math as math_utils
-from omni.isaac.lab.assets import RigidObject
-from omni.isaac.lab.managers import CommandTerm
-from omni.isaac.lab.markers.visualization_markers import VisualizationMarkers
+import isaaclab.utils.math as math_utils
+from isaaclab.assets import RigidObject
+from isaaclab.managers import CommandTerm
+from isaaclab.markers.visualization_markers import VisualizationMarkers
 
 if TYPE_CHECKING:
-    from omni.isaac.lab.envs import ManagerBasedRLEnv
+    from isaaclab.envs import ManagerBasedRLEnv
 
     from .commands_cfg import InHandReOrientationCommandCfg
 

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/events.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/events.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 import torch
 from typing import TYPE_CHECKING, Literal
 
-from omni.isaac.lab.assets import Articulation
-from omni.isaac.lab.managers import EventTermCfg, ManagerTermBase, SceneEntityCfg
-from omni.isaac.lab.utils.math import sample_uniform
+from isaaclab.assets import Articulation
+from isaaclab.managers import EventTermCfg, ManagerTermBase, SceneEntityCfg
+from isaaclab.utils.math import sample_uniform
 
 if TYPE_CHECKING:
-    from omni.isaac.lab.envs import ManagerBasedEnv
+    from isaaclab.envs import ManagerBasedEnv
 
 
 class reset_joints_within_limits_range(ManagerTermBase):

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/observations.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/observations.py
@@ -8,10 +8,10 @@
 import torch
 from typing import TYPE_CHECKING
 
-import omni.isaac.lab.utils.math as math_utils
-from omni.isaac.lab.assets import RigidObject
-from omni.isaac.lab.envs import ManagerBasedRLEnv
-from omni.isaac.lab.managers import SceneEntityCfg
+import isaaclab.utils.math as math_utils
+from isaaclab.assets import RigidObject
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import SceneEntityCfg
 
 if TYPE_CHECKING:
     from .commands import InHandReOrientationCommand

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/rewards.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/rewards.py
@@ -8,10 +8,10 @@
 import torch
 from typing import TYPE_CHECKING
 
-import omni.isaac.lab.utils.math as math_utils
-from omni.isaac.lab.assets import RigidObject
-from omni.isaac.lab.envs import ManagerBasedRLEnv
-from omni.isaac.lab.managers import SceneEntityCfg
+import isaaclab.utils.math as math_utils
+from isaaclab.assets import RigidObject
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import SceneEntityCfg
 
 if TYPE_CHECKING:
     from .commands import InHandReOrientationCommand

--- a/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/terminations.py
+++ b/isaacLab/manipulation/tasks/Dextrous_hand/inhand/mdp/terminations.py
@@ -8,8 +8,8 @@
 import torch
 from typing import TYPE_CHECKING
 
-from omni.isaac.lab.envs import ManagerBasedRLEnv
-from omni.isaac.lab.managers import SceneEntityCfg
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import SceneEntityCfg
 
 if TYPE_CHECKING:
     from .commands import InHandReOrientationCommand

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/franka/__init__.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/franka/__init__.py
@@ -17,7 +17,7 @@ from . import agents, ik_abs_env_cfg, ik_rel_env_cfg, joint_pos_env_cfg
 
 gym.register(
     id="Template-Isaac-Reach-Franka-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": joint_pos_env_cfg.FrankaReachEnvCfg,
@@ -29,7 +29,7 @@ gym.register(
 
 gym.register(
     id="Template-Isaac-Reach-Franka-Play-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": joint_pos_env_cfg.FrankaReachEnvCfg_PLAY,
@@ -46,7 +46,7 @@ gym.register(
 
 gym.register(
     id="Template-Isaac-Reach-Franka-IK-Abs-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": ik_abs_env_cfg.FrankaReachEnvCfg,
     },
@@ -59,7 +59,7 @@ gym.register(
 
 gym.register(
     id="Template-Isaac-Reach-Franka-IK-Rel-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": ik_rel_env_cfg.FrankaReachEnvCfg,
     },

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/franka/agents/rsl_rl_cfg.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/franka/agents/rsl_rl_cfg.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from omni.isaac.lab.utils import configclass
+from isaaclab.utils import configclass
 
-from omni.isaac.lab_tasks.utils.wrappers.rsl_rl import (
+from isaaclab_rl.rsl_rl import (
     RslRlOnPolicyRunnerCfg,
     RslRlPpoActorCriticCfg,
     RslRlPpoAlgorithmCfg,

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/franka/ik_abs_env_cfg.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/franka/ik_abs_env_cfg.py
@@ -3,16 +3,16 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from omni.isaac.lab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
-from omni.isaac.lab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
-from omni.isaac.lab.utils import configclass
+from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
+from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
+from isaaclab.utils import configclass
 
 from . import joint_pos_env_cfg
 
 ##
 # Pre-defined configs
 ##
-from omni.isaac.lab_assets.franka import FRANKA_PANDA_HIGH_PD_CFG  # isort: skip
+from isaaclab_assets.robots.franka import FRANKA_PANDA_HIGH_PD_CFG  # isort: skip
 
 
 @configclass

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/franka/ik_rel_env_cfg.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/franka/ik_rel_env_cfg.py
@@ -3,16 +3,16 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from omni.isaac.lab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
-from omni.isaac.lab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
-from omni.isaac.lab.utils import configclass
+from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
+from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
+from isaaclab.utils import configclass
 
 from . import joint_pos_env_cfg
 
 ##
 # Pre-defined configs
 ##
-from omni.isaac.lab_assets.franka import FRANKA_PANDA_HIGH_PD_CFG  # isort: skip
+from isaaclab_assets.robots.franka import FRANKA_PANDA_HIGH_PD_CFG  # isort: skip
 
 
 @configclass

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/franka/joint_pos_env_cfg.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/franka/joint_pos_env_cfg.py
@@ -5,18 +5,18 @@
 
 import math
 
-from omni.isaac.lab.utils import configclass
+from isaaclab.utils import configclass
 
-#import omni.isaac.lab_tasks.manager_based.manipulation.reach.mdp as mdp
+#import isaaclab_tasks.manager_based.manipulation.reach.mdp as mdp
 import isaacLab.manipulation.tasks.Robot_arm.reach.mdp as mdp
 
 from isaacLab.manipulation.tasks.Robot_arm.reach.reach_env_cfg import ReachEnvCfg
-#from omni.isaac.lab_tasks.manager_based.manipulation.reach.reach_env_cfg import ReachEnvCfg
+#from isaaclab_tasks.manager_based.manipulation.reach.reach_env_cfg import ReachEnvCfg
 
 ##
 # Pre-defined configs
 ##
-from omni.isaac.lab_assets import FRANKA_PANDA_CFG  # isort: skip
+from isaaclab_assets import FRANKA_PANDA_CFG  # isort: skip
 
 
 ##

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/kinova_gripper/__init__.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/kinova_gripper/__init__.py
@@ -13,7 +13,7 @@ from . import agents, joint_pos_env_cfg
 
 gym.register(
     id="Template-Isaac-Reach-Kinova-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": joint_pos_env_cfg.KinovaReachEnvCfg,
@@ -25,7 +25,7 @@ gym.register(
 
 gym.register(
     id="Template-Isaac-Reach-Kinova-Play-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": joint_pos_env_cfg.KinovaReachEnvCfg_PLAY,

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/kinova_gripper/agents/rsl_rl_ppo_cfg.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/kinova_gripper/agents/rsl_rl_ppo_cfg.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from omni.isaac.lab.utils import configclass
+from isaaclab.utils import configclass
 
-from omni.isaac.lab_tasks.utils.wrappers.rsl_rl import (
+from isaaclab_rl.rsl_rl import (
     RslRlOnPolicyRunnerCfg,
     RslRlPpoActorCriticCfg,
     RslRlPpoAlgorithmCfg,

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/kinova_gripper/joint_pos_env_cfg.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/kinova_gripper/joint_pos_env_cfg.py
@@ -5,12 +5,12 @@
 
 import math
 
-from omni.isaac.lab.utils import configclass
+from isaaclab.utils import configclass
 
-#import omni.isaac.lab_tasks.manager_based.manipulation.reach.mdp as mdp
+#import isaaclab_tasks.manager_based.manipulation.reach.mdp as mdp
 import isaacLab.manipulation.tasks.Robot_arm.reach.mdp as mdp
 from isaacLab.manipulation.tasks.Robot_arm.reach.reach_env_cfg import ReachEnvCfg
-#from omni.isaac.lab_tasks.manager_based.manipulation.reach.reach_env_cfg import ReachEnvCfg
+#from isaaclab_tasks.manager_based.manipulation.reach.reach_env_cfg import ReachEnvCfg
 
 ##
 # Pre-defined configs

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/ur_10/__init__.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/ur_10/__init__.py
@@ -13,7 +13,7 @@ from . import agents, joint_pos_env_cfg
 
 gym.register(
     id="Template-Isaac-Reach-UR10-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": joint_pos_env_cfg.UR10ReachEnvCfg,
@@ -25,7 +25,7 @@ gym.register(
 
 gym.register(
     id="Template-Isaac-Reach-UR10-Play-v0",
-    entry_point="omni.isaac.lab.envs:ManagerBasedRLEnv",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": joint_pos_env_cfg.UR10ReachEnvCfg_PLAY,

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/ur_10/agents/rsl_rl_ppo_cfg.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/ur_10/agents/rsl_rl_ppo_cfg.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from omni.isaac.lab.utils import configclass
+from isaaclab.utils import configclass
 
-from omni.isaac.lab_tasks.utils.wrappers.rsl_rl import (
+from isaaclab_rl.rsl_rl import (
     RslRlOnPolicyRunnerCfg,
     RslRlPpoActorCriticCfg,
     RslRlPpoAlgorithmCfg,

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/config/ur_10/joint_pos_env_cfg.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/config/ur_10/joint_pos_env_cfg.py
@@ -5,17 +5,17 @@
 
 import math
 
-from omni.isaac.lab.utils import configclass
+from isaaclab.utils import configclass
 
-#import omni.isaac.lab_tasks.manager_based.manipulation.reach.mdp as mdp
+#import isaaclab_tasks.manager_based.manipulation.reach.mdp as mdp
 import isaacLab.manipulation.tasks.Robot_arm.reach.mdp as mdp
 from isaacLab.manipulation.tasks.Robot_arm.reach.reach_env_cfg import ReachEnvCfg
-#from omni.isaac.lab_tasks.manager_based.manipulation.reach.reach_env_cfg import ReachEnvCfg
+#from isaaclab_tasks.manager_based.manipulation.reach.reach_env_cfg import ReachEnvCfg
 
 ##
 # Pre-defined configs
 ##
-from omni.isaac.lab_assets import UR10_CFG  # isort: skip
+from isaaclab_assets import UR10_CFG  # isort: skip
 
 
 ##

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/__init__.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/__init__.py
@@ -5,7 +5,7 @@
 
 """This sub-module contains the functions that are specific to the lift environments."""
 
-from omni.isaac.lab.envs.mdp import *  # noqa: F401, F403
+from isaaclab.envs.mdp import *  # noqa: F401, F403
 
 from .observations import *  # noqa: F401, F403
 from .rewards import *  # noqa: F401, F403

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/actions.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/actions.py
@@ -7,17 +7,17 @@ from __future__ import annotations
 
 import torch
 from collections.abc import Sequence
-import omni.isaac.lab.utils.math as math_utils
+import isaaclab.utils.math as math_utils
 
 import carb
 
-import omni.isaac.lab.utils.string as string_utils
-from omni.isaac.lab.assets.articulation import Articulation
-from omni.isaac.lab.managers.action_manager import ActionTerm
-from omni.isaac.lab.managers import SceneEntityCfg
+import isaaclab.utils.string as string_utils
+from isaaclab.assets.articulation import Articulation
+from isaaclab.managers.action_manager import ActionTerm
+from isaaclab.managers import SceneEntityCfg
 
 
-from omni.isaac.lab.envs import ManagerBasedEnv
+from isaaclab.envs import ManagerBasedEnv
 
 from . import actions_cfg
 

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/actions_cfg.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/actions_cfg.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from dataclasses import MISSING
 
-from omni.isaac.lab.controllers import DifferentialIKControllerCfg
-from omni.isaac.lab.managers.action_manager import ActionTerm, ActionTermCfg
-from omni.isaac.lab.utils import configclass
+from isaaclab.controllers import DifferentialIKControllerCfg
+from isaaclab.managers.action_manager import ActionTerm, ActionTermCfg
+from isaaclab.utils import configclass
 
 from . import actions
 

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/observations.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/observations.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 import torch
 from typing import TYPE_CHECKING
 
-from omni.isaac.lab.assets import Articulation, RigidObject
-from omni.isaac.lab.managers import SceneEntityCfg
-from omni.isaac.lab.utils.math import subtract_frame_transforms
-from omni.isaac.lab.sensors import FrameTransformer
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.math import subtract_frame_transforms
+from isaaclab.sensors import FrameTransformer
 
 if TYPE_CHECKING:
-    from omni.isaac.lab.envs import ManagerBasedEnv, ManagerBasedRLEnv
+    from isaaclab.envs import ManagerBasedEnv, ManagerBasedRLEnv
 
 
 def object_position_in_robot_root_frame(

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/rewards.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/rewards.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 import torch
 from typing import TYPE_CHECKING
 
-from omni.isaac.lab.assets import RigidObject
-from omni.isaac.lab.managers import SceneEntityCfg
-from omni.isaac.lab.sensors import FrameTransformer
-from omni.isaac.lab.utils.math import combine_frame_transforms, quat_error_magnitude, quat_mul
+from isaaclab.assets import RigidObject
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import FrameTransformer
+from isaaclab.utils.math import combine_frame_transforms, quat_error_magnitude, quat_mul
 
 if TYPE_CHECKING:
-    from omni.isaac.lab.envs import ManagerBasedRLEnv
+    from isaaclab.envs import ManagerBasedRLEnv
 
 
 def object_is_lifted(

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/terminations.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/mdp/terminations.py
@@ -5,7 +5,7 @@
 
 """Common functions that can be used to activate certain terminations for the lift task.
 
-The functions can be passed to the :class:`omni.isaac.lab.managers.TerminationTermCfg` object to enable
+The functions can be passed to the :class:`isaaclab.managers.TerminationTermCfg` object to enable
 the termination introduced by the function.
 """
 
@@ -14,14 +14,14 @@ from __future__ import annotations
 import torch
 from typing import TYPE_CHECKING
 
-from omni.isaac.lab.assets import RigidObject
-from omni.isaac.lab.managers import SceneEntityCfg
-from omni.isaac.lab.utils.math import combine_frame_transforms
-from omni.isaac.lab.sensors import FrameTransformer
-from omni.isaac.lab.assets import Articulation, RigidObject
+from isaaclab.assets import RigidObject
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.math import combine_frame_transforms
+from isaaclab.sensors import FrameTransformer
+from isaaclab.assets import Articulation, RigidObject
 
 if TYPE_CHECKING:
-    from omni.isaac.lab.envs import ManagerBasedRLEnv
+    from isaaclab.envs import ManagerBasedRLEnv
 
 
 def object_reached_goal(

--- a/isaacLab/manipulation/tasks/Robot_arm/reach/reach_env_cfg.py
+++ b/isaacLab/manipulation/tasks/Robot_arm/reach/reach_env_cfg.py
@@ -5,21 +5,21 @@
 
 from dataclasses import MISSING
 
-import omni.isaac.lab.sim as sim_utils
-from omni.isaac.lab.assets import ArticulationCfg, AssetBaseCfg
-from omni.isaac.lab.envs import ManagerBasedRLEnvCfg
-from omni.isaac.lab.managers import ActionTermCfg as ActionTerm
-from omni.isaac.lab.managers import CurriculumTermCfg as CurrTerm
-from omni.isaac.lab.managers import EventTermCfg as EventTerm
-from omni.isaac.lab.managers import ObservationGroupCfg as ObsGroup
-from omni.isaac.lab.managers import ObservationTermCfg as ObsTerm
-from omni.isaac.lab.managers import RewardTermCfg as RewTerm
-from omni.isaac.lab.managers import SceneEntityCfg
-from omni.isaac.lab.managers import TerminationTermCfg as DoneTerm
-from omni.isaac.lab.scene import InteractiveSceneCfg
-from omni.isaac.lab.utils import configclass
-from omni.isaac.lab.utils.assets import ISAAC_NUCLEUS_DIR
-from omni.isaac.lab.utils.noise import AdditiveUniformNoiseCfg as Unoise
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
+from isaaclab.envs import ManagerBasedRLEnvCfg
+from isaaclab.managers import ActionTermCfg as ActionTerm
+from isaaclab.managers import CurriculumTermCfg as CurrTerm
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils.noise import AdditiveUniformNoiseCfg as Unoise
 
 import isaacLab.manipulation.tasks.Robot_arm.reach.mdp as mdp
 

--- a/isaacLab/manipulation/tasks/__init__.py
+++ b/isaacLab/manipulation/tasks/__init__.py
@@ -17,7 +17,7 @@ __version__ = LAB_TASKS_METADATA["package"]["version"]
 # Register Gym environments.
 ##
 
-from omni.isaac.lab_tasks.utils import import_packages
+from isaaclab_tasks.utils import import_packages
 
 # The blacklist is used to prevent importing configs from sub-packages
 _BLACKLIST_PKGS = ["utils"]

--- a/scripts/rsl_rl/cli_args.py
+++ b/scripts/rsl_rl/cli_args.py
@@ -4,7 +4,7 @@ import argparse
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from omni.isaac.lab_tasks.utils.wrappers.rsl_rl import RslRlOnPolicyRunnerCfg
+    from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg
 
 
 def add_rsl_rl_args(parser: argparse.ArgumentParser):
@@ -43,7 +43,7 @@ def parse_rsl_rl_cfg(task_name: str, args_cli: argparse.Namespace) -> RslRlOnPol
     Returns:
         The parsed configuration for RSL-RL agent based on inputs.
     """
-    from omni.isaac.lab_tasks.utils.parse_cfg import load_cfg_from_registry
+    from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
 
     # load the default configuration
     rslrl_cfg: RslRlOnPolicyRunnerCfg = load_cfg_from_registry(task_name, "rsl_rl_cfg_entry_point")

--- a/scripts/rsl_rl/play.py
+++ b/scripts/rsl_rl/play.py
@@ -3,8 +3,8 @@
 """Launch Isaac Sim Simulator first."""
 
 import argparse
-from omni.isaac.lab import __version__ as omni_isaac_lab_version
-from omni.isaac.lab.app import AppLauncher
+from isaaclab import __version__ as omni_isaac_lab_version
+from isaaclab.app import AppLauncher
 
 # local imports
 import cli_args  # isort: skip
@@ -35,9 +35,9 @@ import torch
 
 from isaacLab.manipulation.algorithms.rsl_rl.rsl_rl.runners import OnPolicyRunner
 
-import omni.isaac.lab_tasks  # noqa: F401
-from omni.isaac.lab_tasks.utils import get_checkpoint_path, parse_env_cfg
-from omni.isaac.lab_tasks.utils.wrappers.rsl_rl import (
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils import get_checkpoint_path, parse_env_cfg
+from isaaclab_rl.rsl_rl import (
     RslRlOnPolicyRunnerCfg,
     RslRlVecEnvWrapper,
     export_policy_as_onnx,

--- a/scripts/rsl_rl/train.py
+++ b/scripts/rsl_rl/train.py
@@ -4,8 +4,8 @@
 
 import argparse
 import os
-from omni.isaac.lab import __version__ as omni_isaac_lab_version
-from omni.isaac.lab.app import AppLauncher
+from isaaclab import __version__ as omni_isaac_lab_version
+from isaaclab.app import AppLauncher
 
 # local imports
 import cli_args  # isort: skip
@@ -39,12 +39,12 @@ from datetime import datetime
 
 from isaacLab.manipulation.algorithms.rsl_rl.rsl_rl.runners import OnPolicyRunner
 
-import omni.isaac.lab_tasks  # noqa: F401
-from omni.isaac.lab.envs import ManagerBasedRLEnvCfg
-from omni.isaac.lab.utils.dict import print_dict
-from omni.isaac.lab.utils.io import dump_pickle, dump_yaml
-from omni.isaac.lab_tasks.utils import get_checkpoint_path, parse_env_cfg
-from omni.isaac.lab_tasks.utils.wrappers.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlVecEnvWrapper
+import isaaclab_tasks  # noqa: F401
+from isaaclab.envs import ManagerBasedRLEnvCfg
+from isaaclab.utils.dict import print_dict
+from isaaclab.utils.io import dump_pickle, dump_yaml
+from isaaclab_tasks.utils import get_checkpoint_path, parse_env_cfg
+from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlVecEnvWrapper
 
 # Import extensions to set up environment tasks
 import isaacLab.manipulation.tasks  # noqa: F401  TODO: import lab.<your_extension_name>

--- a/scripts/tools/convert_urdf.py
+++ b/scripts/tools/convert_urdf.py
@@ -31,7 +31,7 @@ optional arguments:
 
 import argparse
 
-from omni.isaac.lab.app import AppLauncher
+from isaaclab.app import AppLauncher
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Utility to convert a URDF into USD format.")
@@ -68,9 +68,9 @@ import carb
 import omni.isaac.core.utils.stage as stage_utils
 import omni.kit.app
 
-from omni.isaac.lab.sim.converters import UrdfConverter, UrdfConverterCfg
-from omni.isaac.lab.utils.assets import check_file_path
-from omni.isaac.lab.utils.dict import print_dict
+from isaaclab.sim.converters import UrdfConverter, UrdfConverterCfg
+from isaaclab.utils.assets import check_file_path
+from isaaclab.utils.dict import print_dict
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 assets_path = os.path.join(BASE_DIR, "../../isaacLab/manipulation/assets/")


### PR DESCRIPTION
**更改内容**
本 PR 对文档做了以下改进：
- 明确指定了 rsl_rl 的兼容版本（v2.0.1，commit 73fd7c6），以解决 TypeError: PPO.__init__() got an unexpected keyword argument 'multi_gpu_cfg' 错误。
- 根据isaaclab官方更新文档（https://github.com/isaac-sim/IsaacLab/releases/tag/v2.0.0）里的Migration guide对相关Module；进行了重命名 

**为何做这些更改**
这些文档更新能帮助新用户避免遇到同样的问题，并明确说明项目依赖的具体版本要求。特别是：
- 使用新版本 rsl_rl 会导致训练脚本失败，明确指定版本可以避免这个常见错误
- IsaacLab 版本更新时模块名称变化的说明能帮助用户正确适配不同版本

**测试方法**
按照更新后的文档说明安装特定版本的 rsl_rl 并运行训练脚本，验证了问题已解决。
